### PR TITLE
ci: update platform for c++20 support

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,8 +2,7 @@ bcr_test_module:
   module_path: ""
   matrix:
     platform:
-      - debian10
-      - ubuntu2004
+      - ubuntu2204
       - macos
     bazel: [7.x, 8.x, 9.x]
   tasks:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_verilator",
-    version = "0.3.3",
+    version = "0.3.3.bcr.1",
     bazel_compatibility = [">=7.6.0"],
 )
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bazel rules for Verilator-based SystemVerilog simulation using the Bazel Central
 Add the following to your `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "rules_verilator", version = "0.3.3")
+bazel_dep(name = "rules_verilator", version = "0.3.3.bcr.1")
 register_toolchains(
     "@rules_verilator//verilator:verilator_toolchain",
 )
@@ -32,7 +32,7 @@ The default toolchain supports C++ output only and does not require SystemC.
 If you need SystemC output, add the SystemC dependency and register the SystemC-enabled toolchain:
 
 ```starlark
-bazel_dep(name = "rules_verilator", version = "0.3.3")
+bazel_dep(name = "rules_verilator", version = "0.3.3.bcr.1")
 bazel_dep(name = "systemc", version = "3.0.2")
 
 # Register the SystemC-enabled toolchain

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """package version"""
 
-VERSION = "0.3.3"
+VERSION = "0.3.3.bcr.1"


### PR DESCRIPTION
Drop the debian10 and ubuntu2004 presubmit CI jobs, since upstream (verilator with timing support) now depends on C++20 coroutines and older GCC versions are unable to compile them
related to  https://github.com/bazelbuild/bazel-central-registry/pull/8989#issuecomment-4550769376