### PR TITLE
feat: add trace_mode attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ verilog_library(
 verilator_cc_library(
     name = "my_verilated_lib",
     module = ":my_module",
-    timing = True,  # Enable timing support (--timing)
-    trace = True,   # Enable waveform tracing (--trace)
+    timing = True,  # Enable timing support (--timing), optional
+    trace_mode = "vcd",  # Enable waveform tracing ("vcd", "fst", "saif"), optional
     vopts = [
         "-Wall",
         "--x-assign fast",
@@ -75,7 +75,10 @@ cc_binary(
 )
 ```
 
-`module_top` remains available as an override when you need to verilate a different top than the one declared on the `verilog_library`, but the recommended style is to put the canonical top in `verilog_library(top_module = ...)`.
+- `module_top` remains available as an override when you need to verilate a different top than the one declared on the `verilog_library`, but the recommended style is to put the canonical top in `verilog_library(top_module = ...)`.
+- Use the dedicated `timing` attribute instead of passing `--timing` or `--no-timing` through `vopts`.
+- Use the dedicated `trace_mode` attribute instead of passing `--trace`, `--trace-vcd`, `--trace-fst`, or `--trace-saif` through `vopts`.
+- `trace = True` remains supported as a compatibility alias for `trace_mode = "vcd"`.
 
 ### Verilator SystemC Library
 
@@ -94,7 +97,7 @@ verilator_cc_library(
     module = ":my_module",
     systemc = True,  # Generate SystemC output
     timing = True,
-    trace = True,
+    trace_mode = "vcd",  # Enable waveform tracing ("vcd", "fst", "saif")
     vopts = ["-Wall"],
 )
 
@@ -171,6 +174,8 @@ Important behavior:
 - `hierarchical = True` changes the compile strategy for this target only. The same `verilog_library` graph can still be consumed by a separate flat `verilator_cc_library`.
 - Rebuilds happen at hierarchy-node granularity: if one child node changes, unchanged sibling nodes can still be reused from cache, while the changed node and its ancestor chain are rebuilt.
 - Use the dedicated `timing` attribute instead of passing `--timing` or `--no-timing` through `vopts`.
+- Use the dedicated `trace_mode` attribute instead of passing `--trace`, `--trace-vcd`, `--trace-fst`, or `--trace-saif` through `vopts`.
+- `trace = True` remains supported as a compatibility alias for `trace_mode = "vcd"`.
 - `systemc = True` is supported only for flat Verilation today.
 - The rule auto-generates the temporary `.vlt` control file. Users do not need to maintain it manually.
 

--- a/verilator/private/common.bzl
+++ b/verilator/private/common.bzl
@@ -15,7 +15,22 @@ _MANAGED_VOPT_TO_ATTR = {
     "--no-timing": "timing",
     "--sc": "systemc",
     "--timing": "timing",
-    "--trace": "trace",
+    "--trace": "trace_mode",
+    "--trace-fst": "trace_mode",
+    "--trace-saif": "trace_mode",
+    "--trace-vcd": "trace_mode",
+}
+_TRACE_MODE_TO_VERILATOR_FLAG = {
+    "fst": "--trace-fst",
+    "none": None,
+    "saif": "--trace-saif",
+    "vcd": "--trace-vcd",
+}
+_TRACE_MODE_TO_DEFINES = {
+    "fst": ["VM_TRACE", "VM_TRACE_FST"],
+    "none": [],
+    "saif": ["VM_TRACE", "VM_TRACE_SAIF"],
+    "vcd": ["VM_TRACE", "VM_TRACE_VCD"],
 }
 
 def _verilator_timing_transition_impl(_settings, _attr):
@@ -192,11 +207,32 @@ def validate_verilator_options(verilator_toolchain, vopts, owner):
     reject_managed_vopts(verilator_toolchain.extra_vopts, "verilator_toolchain.extra_vopts")
     reject_managed_vopts(vopts, "{}.vopts".format(owner))
 
+def resolve_trace_mode(trace, trace_mode, owner):
+    """Resolve the effective trace mode, honoring the deprecated `trace` alias.
+
+    Args:
+        trace: Whether the deprecated boolean tracing alias was enabled.
+        trace_mode: The requested structured trace mode.
+        owner: Human-readable label used in validation errors.
+
+    Returns:
+        The effective trace mode after applying compatibility behavior.
+    """
+    if trace:
+        if trace_mode == "none":
+            return "vcd"
+        if trace_mode != "vcd":
+            fail(
+                "{} sets deprecated `trace = True` together with incompatible `trace_mode = \"{}\"`. ".format(owner, trace_mode) +
+                "Use `trace_mode` alone, or keep `trace = True` only for VCD compatibility.",
+            )
+    return trace_mode
+
 def add_common_verilator_args(
         args,
         verilator_toolchain,
         timing,
-        trace,
+        trace_mode,
         includes,
         verilog_files,
         vopts):
@@ -206,19 +242,24 @@ def add_common_verilator_args(
         args: The action args object to append flags to.
         verilator_toolchain: The resolved Verilator toolchain info.
         timing: Whether to enable Verilator timing support.
-        trace: Whether to enable Verilator tracing support.
+        trace_mode: Which Verilator tracing mode to enable.
         includes: Include search paths to pass as `-I` flags.
         verilog_files: Verilog/SystemVerilog source inputs for the action.
         vopts: Additional user-supplied Verilator options.
     """
     if timing:
         args.add("--timing")
-    if trace:
-        args.add("--trace")
+    trace_flag = _TRACE_MODE_TO_VERILATOR_FLAG[trace_mode]
+    if trace_flag != None:
+        args.add(trace_flag)
     args.add_all(includes, format_each = "-I%s")
     args.add_all(verilog_files, expand_directories = True, map_each = only_sv)
     args.add_all(verilator_toolchain.extra_vopts)
     args.add_all(vopts, expand_directories = False)
+
+def trace_defines(trace_mode):
+    """Return the compile-time trace defines required by the selected trace mode."""
+    return _TRACE_MODE_TO_DEFINES[trace_mode]
 
 def partition_verilog_inputs(files):
     """Split a file list into compile-time Verilog inputs and runtime files.

--- a/verilator/private/hierarchical.bzl
+++ b/verilator/private/hierarchical.bzl
@@ -10,6 +10,7 @@ load(
     "only_sv",
     "timing_copts",
     "timing_deps",
+    "trace_defines",
     "validate_verilator_options",
     "verilator_env",
 )
@@ -27,7 +28,7 @@ def _copy_file_from_tree(ctx, generated_dir, output, relative_paths):
         mnemonic = "VerilatorCopyFile",
     )
 
-def _run_hierarchical_discovery(ctx, verilator_toolchain, root_module_top, node_plan):
+def _run_hierarchical_discovery(ctx, verilator_toolchain, root_module_top, node_plan, trace_mode):
     # Run Verilator once in discovery mode to ask it how to compile each
     # hierarchical node. The resulting `__hierMkJsonArgs.f` files drive all
     # subsequent per-node compile actions.
@@ -58,7 +59,7 @@ def _run_hierarchical_discovery(ctx, verilator_toolchain, root_module_top, node_
         args,
         verilator_toolchain,
         timing = ctx.attr.timing,
-        trace = ctx.attr.trace,
+        trace_mode = trace_mode,
         includes = verilog_inputs.includes,
         verilog_files = verilog_inputs.verilog_files,
         vopts = ctx.attr.vopts,
@@ -94,7 +95,7 @@ def _run_hierarchical_discovery(ctx, verilator_toolchain, root_module_top, node_
         control_file = control_file,
     )
 
-def _compile_hierarchy_node(ctx, verilator_toolchain, root_module_top, node_name, node, child_results, discovery):
+def _compile_hierarchy_node(ctx, verilator_toolchain, root_module_top, node_name, node, child_results, discovery, trace_mode):
     generated_dir = ctx.actions.declare_directory(ctx.label.name + "_" + node_name + "_gen")
     output_stem = ctx.label.name + "_" + node_name
     is_root = node_name == root_module_top
@@ -118,7 +119,7 @@ def _compile_hierarchy_node(ctx, verilator_toolchain, root_module_top, node_name
         args,
         verilator_toolchain,
         timing = ctx.attr.timing,
-        trace = ctx.attr.trace,
+        trace_mode = trace_mode,
         includes = node["includes"],
         verilog_files = node["compile_files"],
         vopts = ctx.attr.vopts,
@@ -148,7 +149,7 @@ def _compile_hierarchy_node(ctx, verilator_toolchain, root_module_top, node_name
         )
 
     copied_outputs = copy_generated_cpp_and_hpp(ctx, generated_dir, output_stem = output_stem)
-    defines = ["VM_TRACE"] if ctx.attr.trace else []
+    defines = trace_defines(trace_mode)
     deps = timing_deps(
         ctx,
         verilator_toolchain,
@@ -177,20 +178,21 @@ def _compile_hierarchy_node(ctx, verilator_toolchain, root_module_top, node_name
         wrapper_sv = wrapper_sv,
     )
 
-def compile_hierarchical_verilator_library(ctx, verilator_toolchain, root_module_top):
+def compile_hierarchical_verilator_library(ctx, verilator_toolchain, root_module_top, trace_mode):
     """Compile a verilog_library graph using automatic hierarchy discovery.
 
     Args:
         ctx: Rule context for the owning `verilator_cc_library`.
         verilator_toolchain: The resolved Verilator toolchain info.
         root_module_top: The resolved root top module name for this build.
+        trace_mode: The selected trace mode for all discovery and node compile actions.
 
     Returns:
         A `[DefaultInfo, CcInfo]` pair for the root hierarchical library.
     """
     graph_info = ctx.attr.module[VerilatorVerilogGraphInfo]
     node_plan = build_hierarchy_plan(graph_info, root_module_top)
-    discovery = _run_hierarchical_discovery(ctx, verilator_toolchain, root_module_top, node_plan)
+    discovery = _run_hierarchical_discovery(ctx, verilator_toolchain, root_module_top, node_plan, trace_mode)
 
     compiled_nodes = {}
 
@@ -207,6 +209,7 @@ def compile_hierarchical_verilator_library(ctx, verilator_toolchain, root_module
             node,
             child_results,
             discovery,
+            trace_mode,
         )
 
     root_result = compiled_nodes[root_module_top]

--- a/verilator/private/verilator_cc_library.bzl
+++ b/verilator/private/verilator_cc_library.bzl
@@ -8,8 +8,10 @@ load(
     "cc_compile_and_link_static_library",
     "collect_verilog_inputs",
     "copy_generated_cpp_and_hpp",
+    "resolve_trace_mode",
     "timing_copts",
     "timing_deps",
+    "trace_defines",
     "validate_verilator_options",
     "verilator_env",
     "verilator_no_timing_transition",
@@ -28,10 +30,11 @@ load(
 def _verilator_cc_library_impl(ctx):
     verilator_toolchain = ctx.toolchains["//verilator:toolchain_type"]
     module_top = resolve_module_top(ctx.attr.module, ctx.attr.module_top, ctx.label)
+    trace_mode = resolve_trace_mode(ctx.attr.trace, ctx.attr.trace_mode, ctx.label)
     if ctx.attr.hierarchical:
         if ctx.attr.systemc:
             fail("hierarchical Verilation currently supports only C++ output; set systemc = False.")
-        return compile_hierarchical_verilator_library(ctx, verilator_toolchain, module_top)
+        return compile_hierarchical_verilator_library(ctx, verilator_toolchain, module_top, trace_mode)
 
     # Flat mode keeps the original behavior: flatten the Verilog graph, run
     # Verilator once, then compile the generated C++ as a single static library.
@@ -61,7 +64,7 @@ def _verilator_cc_library_impl(ctx):
         args,
         verilator_toolchain,
         timing = timing,
-        trace = ctx.attr.trace,
+        trace_mode = trace_mode,
         includes = verilog_inputs.includes,
         verilog_files = verilog_inputs.verilog_files,
         vopts = ctx.attr.vopts,
@@ -79,7 +82,7 @@ def _verilator_cc_library_impl(ctx):
     )
 
     copied_outputs = copy_generated_cpp_and_hpp(ctx, verilator_output)
-    defines = ["VM_TRACE"] if ctx.attr.trace else []
+    defines = trace_defines(trace_mode)
     deps = timing_deps(
         ctx,
         verilator_toolchain,
@@ -128,8 +131,13 @@ verilator_cc_library = rule(
             default = False,
         ),
         "trace": attr.bool(
-            doc = "Enable tracing for Verilator",
+            doc = "Deprecated compatibility alias for `trace_mode = \"vcd\"`.",
             default = False,
+        ),
+        "trace_mode": attr.string(
+            doc = "Waveform trace mode: `none`, `vcd`, `fst`, or `saif`.",
+            default = "none",
+            values = ["none", "vcd", "fst", "saif"],
         ),
         "vopts": attr.string_list(
             doc = "Additional command line options to pass to Verilator",

--- a/verilator/tests/adder/BUILD
+++ b/verilator/tests/adder/BUILD
@@ -28,7 +28,19 @@ verilator_cc_library(
 verilator_cc_library(
     name = "adder_trace_verilator",
     module = ":adder",
+    trace_mode = "vcd",
+)
+
+verilator_cc_library(
+    name = "adder_trace_compat_verilator",
+    module = ":adder",
     trace = True,
+)
+
+verilator_cc_library(
+    name = "adder_fst_verilator",
+    module = ":adder",
+    trace_mode = "fst",
 )
 
 cc_test(
@@ -55,6 +67,24 @@ cc_test(
     srcs = ["adder_trace_test.cc"],
     deps = [
         ":adder_trace_verilator",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "adder_trace_compat_test",
+    srcs = ["adder_trace_test.cc"],
+    deps = [
+        ":adder_trace_compat_verilator",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "adder_fst_test",
+    srcs = ["adder_fst_test.cc"],
+    deps = [
+        ":adder_fst_verilator",
         "@googletest//:gtest_main",
     ],
 )

--- a/verilator/tests/adder/adder_fst_test.cc
+++ b/verilator/tests/adder/adder_fst_test.cc
@@ -1,0 +1,34 @@
+#include <verilated.h>
+#include <verilated_fst_c.h>
+
+#include <memory>
+
+#include "Vadder.h"
+#include "gtest/gtest.h"
+
+double sc_time_stamp() { return 0; }
+
+namespace {
+
+TEST(AdderFstTest, trace_functionality) {
+  Verilated::traceEverOn(true);
+
+  std::unique_ptr<Vadder> v_adder = std::make_unique<Vadder>();
+  auto trace = std::make_unique<VerilatedFstC>();
+  v_adder->trace(trace.get(), 99);
+  trace->open("adder_trace.fst");
+
+  v_adder->x = 21;
+  v_adder->y = 21;
+  v_adder->carry_in = 0;
+  v_adder->eval();
+  trace->dump(0);
+
+  EXPECT_EQ(v_adder->sum, 42);
+  EXPECT_EQ(v_adder->carry_output_bit, 0);
+
+  trace->close();
+  v_adder->final();
+}
+
+}  // namespace


### PR DESCRIPTION
Use `trace_mode = "vcd"` to enable different format of waveform tracing ("vcd", "fst", "saif") as fst waveform file size is much smaller than vcd.