### PR TITLE
Added `verilator_lint_aspect`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,61 +1,54 @@
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-build --cxxopt "-std=c++17"
-build --cxxopt "-ffp-contract=off"
-build --host_cxxopt "-std=c++17"
-build --host_cxxopt "-ffp-contract=off"
-build --repo_env=CC=clang
-build --repo_env=CXX=clang++
-build --action_env=CC=clang
-build --action_env=CXX=clang++
-
-build:ciremotebuild --bes_backend=grpcs://cloud.buildbuddy.io
-build:ciremotebuild --remote_cache=https://storage.googleapis.com/bazel-cache-rules-hdl
-build:ciremotebuild --google_default_credentials
-build:ciremotebuild --remote_download_outputs=all
-build:ciremotebuild --tls_client_certificate=/root/.ssh/buildbuddy-cert.pem
-build:ciremotebuild --tls_client_key=/root/.ssh/buildbuddy-key.pem
-build:ciremotebuild --build_metadata=VISIBILITY=PUBLIC
-
-test:ciremotebuild --bes_backend=grpcs://cloud.buildbuddy.io
-test:ciremotebuild --remote_cache=grpcs://cloud.buildbuddy.io
-test:ciremotebuild --remote_download_outputs=all
-test:ciremotebuild --google_default_credentials
-test:ciremotebuild --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
-test:ciremotebuild --tls_client_certificate=/root/.ssh/buildbuddy-cert.pem
-test:ciremotebuild --tls_client_key=/root/.ssh/buildbuddy-key.pem
-test:ciremotebuild --build_metadata=VISIBILITY=PUBLIC
-test:ciremotebuild --remote_timeout=3600
-
 ###############################################################################
-## Incompatibility flags
+## Bazel Configuration Flags
+##
+## `.bazelrc` is a Bazel configuration file.
+## https://bazel.build/docs/best-practices#bazelrc-file
 ###############################################################################
+
+# https://bazel.build/reference/command-line-reference#flag--enable_platform_specific_config
+common --enable_platform_specific_config
+
+# Enable the only currently supported report type
+# https://bazel.build/reference/command-line-reference#flag--combined_report
+coverage --combined_report=lcov
+
+# Avoid fully cached builds reporting no coverage and failing CI
+# https://bazel.build/reference/command-line-reference#flag--experimental_fetch_all_coverage_outputs
+coverage --experimental_fetch_all_coverage_outputs
 
 # https://github.com/bazelbuild/bazel/issues/8195
 build --incompatible_disallow_empty_glob=true
 
+# https://github.com/bazelbuild/bazel/issues/12821
+build --nolegacy_external_runfiles
+
+# Disable legacy __init__.py behavior which is known to conflict with
+# modern python versions (3.9+)
+build --incompatible_default_to_explicit_init_py
+
+# https://github.com/bazelbuild/bazel/issues/23043.
+build --incompatible_autoload_externally=
+
+# Show test failures
+common --test_output=errors
+
+###############################################################################
+## Custom configurations
+###############################################################################
+
 # SystemC support configuration
 build:systemc --extra_toolchains=//verilator:verilator_toolchain_with_systemc
 
+# Run linting on all verilog_library targets.
+build:lint --aspects=//verilator:defs.bzl%verilator_lint_aspect
+build:lint --output_groups=verilator_lint_checks
+
 ###############################################################################
-## User flags
+## Custom user flags
+##
+## This should always be the last thing in the `.bazelrc` file to ensure
+## consistent behavior when setting flags in that file as `.bazelrc` files are
+## evaluated top to bottom.
 ###############################################################################
-# Optionally allow users to define custom flags when developing new features.
-# https://bazel.build/configure/best-practices#bazelrc-file
-#
-# Note: This line should always be last in this file to ensure consistent behavior
-# with flags defined in this file.
-#
-try-import %workspace$/user.bazelrc
+
+try-import %workspace%/user.bazelrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,11 @@ jobs:
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel-version }}
         run: bazel test //... --test_output=errors
+
+      - name: Verilator lint aspect
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel-version }}
+        run: |
+          bazel build //... \
+            --aspects=//verilator:defs.bzl%verilator_lint_aspect \
+            --output_groups=verilator_lint_checks

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Bazel rules for Verilator-based SystemVerilog simulation using the Bazel Central
 - Supports both C++ and SystemC output
 - Support incremental hierarchical builds
 - Optional waveform tracing support
+- Repo-wide `verilator --lint-only` aspect
 
 ## Installation
 
@@ -175,6 +176,58 @@ Important behavior:
 - Rebuilds happen at hierarchy-node granularity: if one child node changes, unchanged sibling nodes can still be reused from cache, while the changed node and its ancestor chain are rebuilt.
 - `systemc = True` is supported only for flat Verilation today.
 - The rule auto-generates the temporary `.vlt` control file. Users do not need to maintain it manually.
+
+### Lint Aspect
+
+`verilator_lint_aspect` runs `verilator --lint-only` on every target that provides `VerilogInfo`. It pays for itself in two cases the compile path doesn't cover:
+
+- **Intermediate libraries.** A `verilog_library` that's only ever consumed as a dependency (never wrapped in a `verilator_cc_library`) otherwise has nothing exercising it. The aspect lints it in isolation against its own `top_module`, so issues at a leaf module (unused signals, width truncation, incomplete cases) surface where they live instead of getting masked by the integrated top.
+- **A stricter, repo-wide flag set.** Compile `vopts` are tuned per target for buildability. The aspect's flags come from the new `lint_vopts` attr on `verilator_toolchain` (default `["-Wall"]`), so CI can enforce a stricter posture without changing how any individual `verilator_cc_library` builds.
+
+It's also cheap — no C++ codegen, no link — so it's reasonable to fan out over `//...` on every build.
+
+#### Running it
+
+```bash
+bazel build \
+    --aspects=@rules_verilator//verilator:defs.bzl%verilator_lint_aspect \
+    --output_groups=verilator_lint_checks \
+    //...
+```
+
+Clean lint runs produce no output; failures replay Verilator's diagnostics to stderr and fail the action with Verilator's exit code.
+
+#### Configuring lint flags
+
+Set `lint_vopts` on your `verilator_toolchain` to override the default:
+
+```starlark
+verilator_toolchain(
+    name = "verilator_toolchain_impl",
+    verilator = "@verilator//:verilator_executable",
+    lint_vopts = [
+        "-Wall",
+        "-Wpedantic",
+    ],
+)
+```
+
+The same managed-flag validation that applies to `extra_vopts` and `vopts` applies here — `--cc`, `--sc`, `--timing`, and `--trace*` are rejected; use the dedicated rule attrs.
+
+#### Skipping individual targets
+
+Tag a target with `no-lint` or `no-verilator-lint` to skip it during aspect runs. Underscores and hyphens are interchangeable, so `no_lint` and `no_verilator_lint` also work:
+
+```starlark
+verilog_library(
+    name = "legacy_block",
+    srcs = ["legacy.sv"],
+    top_module = "legacy_block",
+    tags = ["no-verilator-lint"],
+)
+```
+
+Targets without a `top_module` are skipped automatically — they can't be linted in isolation.
 
 ## Key Differences from rules_hdl
 

--- a/verilator/defs.bzl
+++ b/verilator/defs.bzl
@@ -27,8 +27,13 @@ load(
     "//verilator/private:verilator_cc_library.bzl",
     _verilator_cc_library = "verilator_cc_library",
 )
+load(
+    "//verilator/private:verilator_lint_aspect.bzl",
+    _verilator_lint_aspect = "verilator_lint_aspect",
+)
 
 cc_compile_and_link_static_library = _cc_compile_and_link_static_library
 
 verilator_cc_library = _verilator_cc_library
+verilator_lint_aspect = _verilator_lint_aspect
 verilator_toolchain = _verilator_toolchain

--- a/verilator/private/BUILD.bazel
+++ b/verilator/private/BUILD.bazel
@@ -17,3 +17,9 @@ cc_binary(
     srcs = ["verilator_process_wrapper.cc"],
     visibility = ["//visibility:public"],
 )
+
+cc_binary(
+    name = "verilator_lint_wrapper",
+    srcs = ["verilator_lint_wrapper.cc"],
+    visibility = ["//visibility:public"],
+)

--- a/verilator/private/toolchain.bzl
+++ b/verilator/private/toolchain.bzl
@@ -2,15 +2,18 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_cc//cc:defs.bzl", "CcInfo")
+load(":common.bzl", "reject_managed_vopts")
 
 def _verilator_toolchain_impl(ctx):
     all_files = ctx.attr.verilator[DefaultInfo].default_runfiles.files
+    reject_managed_vopts(ctx.attr.lint_vopts, "verilator_toolchain.lint_vopts")
 
     return [platform_common.ToolchainInfo(
         verilator = ctx.executable.verilator,
         systemc = ctx.attr.systemc,
         deps = ctx.attr.deps,
         extra_vopts = ctx.attr.extra_vopts,
+        lint_vopts = ctx.attr.lint_vopts,
         all_files = all_files,
         _avoid_nondeterministic_outputs = ctx.attr.avoid_nondeterministic_outputs[BuildSettingInfo].value,
     )]
@@ -28,6 +31,11 @@ verilator_toolchain = rule(
         ),
         "extra_vopts": attr.string_list(
             doc = "Extra flags to pass to Verilator compile actions.",
+        ),
+        "lint_vopts": attr.string_list(
+            doc = "Default flags passed to `verilator --lint-only` by `verilator_lint_aspect` " +
+                  "and by `verilator_lint_test` when its target is a bare `verilog_library`.",
+            default = ["-Wall"],
         ),
         "systemc": attr.label(
             doc = "SystemC dependency to link into downstream targets.",

--- a/verilator/private/verilator_lint_aspect.bzl
+++ b/verilator/private/verilator_lint_aspect.bzl
@@ -1,0 +1,69 @@
+"""Aspect that runs `verilator --lint-only` on targets providing `VerilogInfo`."""
+
+load("@rules_verilog//verilog:defs.bzl", "VerilogInfo")
+load(
+    ":common.bzl",
+    "collect_verilog_inputs",
+    "only_sv",
+    "verilator_env",
+)
+
+_SKIP_TAGS = ("no-lint", "no-verilator-lint")
+
+def _has_skip_tag(ctx):
+    if not hasattr(ctx.rule.attr, "tags"):
+        return False
+    for tag in ctx.rule.attr.tags:
+        if tag.replace("_", "-") in _SKIP_TAGS:
+            return True
+    return False
+
+def _verilator_lint_aspect_impl(target, ctx):
+    if VerilogInfo not in target:
+        return []
+    if _has_skip_tag(ctx):
+        return []
+    top = target[VerilogInfo].top_module
+    if not top:
+        # A verilog_library without a top_module declaration cannot be linted in
+        # isolation. Skip silently so the aspect can safely fan out across //...
+        return []
+
+    toolchain = ctx.toolchains["//verilator:toolchain_type"]
+    inputs = collect_verilog_inputs(target)
+
+    marker = ctx.actions.declare_file(target.label.name + ".verilator_lint")
+    args = ctx.actions.args()
+    args.add("--marker", marker)
+    args.add(toolchain.verilator)
+    args.add("--no-std")
+    args.add("--lint-only")
+    args.add("--top-module", top)
+    args.add_all(inputs.includes, format_each = "-I%s")
+    args.add_all(inputs.verilog_files, expand_directories = True, map_each = only_sv)
+    args.add_all(toolchain.lint_vopts)
+
+    ctx.actions.run(
+        executable = ctx.executable._lint_wrapper,
+        arguments = [args],
+        outputs = [marker],
+        inputs = inputs.verilog_files,
+        tools = toolchain.all_files,
+        mnemonic = "VerilatorLint",
+        progress_message = "[Verilator] Linting {}".format(target.label),
+        env = verilator_env(toolchain),
+    )
+    return [OutputGroupInfo(verilator_lint_checks = depset([marker]))]
+
+verilator_lint_aspect = aspect(
+    implementation = _verilator_lint_aspect_impl,
+    required_providers = [VerilogInfo],
+    attrs = {
+        "_lint_wrapper": attr.label(
+            cfg = "exec",
+            executable = True,
+            default = Label("//verilator/private:verilator_lint_wrapper"),
+        ),
+    },
+    toolchains = ["//verilator:toolchain_type"],
+)

--- a/verilator/private/verilator_lint_wrapper.cc
+++ b/verilator/private/verilator_lint_wrapper.cc
@@ -1,0 +1,74 @@
+/**
+ * @file verilator_lint_wrapper.cc
+ * @brief Process wrapper for the `VerilatorLint` Bazel action.
+ *
+ * Usage: verilator_lint_wrapper --marker <path> <verilator> [verilator args...]
+ *
+ * Captures the Verilator invocation's stdout+stderr to the marker file. On
+ * success (exit 0) the marker is truncated to zero bytes so the artifact is
+ * deterministic and no output reaches the build log. On failure the captured
+ * log is replayed to stderr and Verilator's exit code is propagated, so Bazel
+ * surfaces the diagnostics that explain the failure and only the failure.
+ */
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main(int argc, char* argv[]) {
+    std::string marker_path{};
+    std::vector<std::string> command{};
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--marker" && i + 1 < argc) {
+            marker_path = argv[++i];
+            continue;
+        }
+        command.push_back(arg);
+    }
+
+    if (marker_path.empty()) {
+        std::cerr << "verilator_lint_wrapper: missing --marker <path>"
+                  << std::endl;
+        return 1;
+    }
+    if (command.empty()) {
+        std::cerr << "verilator_lint_wrapper: no verilator command provided"
+                  << std::endl;
+        return 1;
+    }
+
+    // Redirect Verilator's stdout+stderr into the marker file. The unquoted
+    // form keeps `std::system` portable across POSIX sh and Windows cmd.exe,
+    // matching the project convention that Bazel-out paths contain no spaces
+    // or shell metachars.
+    std::string cmd{};
+    for (const std::string& part : command) {
+        cmd += part + " ";
+    }
+    cmd += "> " + marker_path + " 2>&1";
+
+    int result = std::system(cmd.c_str());
+    if (result != 0) {
+        std::ifstream log(marker_path);
+        if (log.is_open()) {
+            std::cerr << log.rdbuf();
+        } else {
+            std::cerr << "verilator_lint_wrapper: failed to read captured log "
+                      << marker_path << std::endl;
+        }
+        return result;
+    }
+
+    // Truncate so the marker is always zero-bytes on success.
+    std::ofstream marker(marker_path, std::ios::trunc);
+    if (!marker.is_open()) {
+        std::cerr << "verilator_lint_wrapper: failed to write marker "
+                  << marker_path << std::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/verilator/tests/hierarchical/nested/hier_nested_top.sv
+++ b/verilator/tests/hierarchical/nested/hier_nested_top.sv
@@ -1,6 +1,6 @@
 module hier_nested_top(
     input  logic [3:0] x,
-    output logic [5:0] y
+    output logic [4:0] y
 );
   hier_nested_mid u_mid(
       .x(x),


### PR DESCRIPTION
This change introduces an aspect to run `verilator --lint` on `VerilogInfo` providing targets.

The new aspect is driven by a new `verilator_toolchain.lint_vopts` attribute and can be skipped on targets tagged with `no-verilator-lint`.

closes https://github.com/hw-bzl/rules_verilator/issues/19